### PR TITLE
Add note about reason for archiving this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This repo has been archived as [rust-zmq](https://github.com/erickt/rust-zmq) now provides all the functionality we need and therefore we no longer need to maintain our own fork. See [this issue](https://github.com/cambrianworks/iris/issues/111).
+
 # Cambrian Works' Public Fork of rust-zmq 
 
 **We published this crate internally so we can use an unreleased features**


### PR DESCRIPTION
See [this pull request](https://github.com/cambrianworks/iris/pull/115) which removes this dependency from Iris and replaces it with [rust-zmq](https://github.com/erickt/rust-zmq)